### PR TITLE
resolve ssh hostnames into IP addresses

### DIFF
--- a/resync.py
+++ b/resync.py
@@ -652,4 +652,4 @@ finally:
 		ssh_connection.terminate()
 		#os.remove(ssh_socketfile)
 	if os.path.exists(default_prepdir):  # we created this
-		shutil.rmtree(args.prepdir)
+		shutil.rmtree(default_prepdir)

--- a/resync.py
+++ b/resync.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from typing import Optional
+
 import sys
 import os
 import time
@@ -401,7 +403,7 @@ class Folder(Node):
 			ch.render(prepdir)
 
 
-def identify_node(name, parent=None):
+def identify_node(name:str, parent=None)->Optional[Node]:
 	"""
 	infer a node's type by name and location, and return a node object
 	in case this is unambiguously possible


### PR DESCRIPTION
This patch allows specifying SSH hostnames as addresses. The IP required for HTTP access will be deduced. For example, in my `~/.ssh/config` I have the following section.

```
Host remarkable
    Hostname 10.11.99.1
    User root
    ForwardX11         no
    ForwardX11Trusted  no
```

With the patch I now can call the script as `resync.py -r remarkable  backup  -o _rm2sync`