### PR TITLE
Fix extra parenthesis and syntax error in `resync.py`

### DIFF
--- a/resync.py
+++ b/resync.py
@@ -109,7 +109,7 @@ def get_metadata_by_uuid(u):
 	try:
 		metadata = json.loads(raw_metadata)
 
-		if metadata.get('deleted') or metadata.get('parent') == 'trash'):
+		if metadata.get('deleted') or metadata.get('parent') == 'trash':
 			return None
 		else:
 			return metadata


### PR DESCRIPTION
This PR fixes a syntax error in the latest version, removing an extra parenthesis that prevents `resync.py` from running

This behavior appeared to be introduced in 5fa1f2444475d38396a556d9fc9b0abda4122350, when this line was changed from the following:

```python
if metadata['deleted'] or metadata['parent'] == 'trash':
```

This PR uses the older commit as a guide for placing the parenthesis correctly